### PR TITLE
Enhancements to the dependency visualiser

### DIFF
--- a/sandbox/visdep.py
+++ b/sandbox/visdep.py
@@ -26,6 +26,9 @@ Where <switches> are:
                     Omits the checkout nodes from the graph. This is recommended
                     in most cases.
 
+  -s[hort-labels]   Uses short node labels. This makes the graph easier to read,
+                    but can cause confusion in some cases.
+
   -f[ilter] <name>  Tell xdot.py to use the named graphviz filter (one of
                     dot, neato, twopi, circo or fdp). The default is dot.
 
@@ -49,7 +52,7 @@ import subprocess
 import sys
 
 def process(labels, reduce=False, filter='dot', keep_files=False,
-            verbose=False, outputfile=None, hideCheckouts=False):
+            verbose=False, outputfile=None, hideCheckouts=False, shortLabels=False):
 
     # The first program we want to run is in the sandbox with us
     thisdir = os.path.split(__file__)[0]
@@ -68,6 +71,8 @@ def process(labels, reduce=False, filter='dot', keep_files=False,
             labels2 = []
             if hideCheckouts:
                 labels2.append('--hide-checkouts')
+            if shortLabels:
+                labels2.append('--short-labels')
             for label in labels:
                 labels2.append("'%s'"%label)
             retcode = subprocess.call('%s %s'%(visualiser, ' '.join(labels2)),
@@ -144,6 +149,7 @@ def main(args):
     labels = []
     outputfile = None
     hideCheckouts = False
+    shortLabels = False
 
     while args:
         word = args.pop(0)
@@ -163,13 +169,15 @@ def main(args):
             args = args[1:]
         elif word in ('-c', '-hide-checkouts'):
             hideCheckouts = True
+        elif word in ('-s', '-short-labels'):
+            shortLabels = True
         elif word[0] == '-':
             print 'Unrecognised switch', word
             return
         else:
             labels.append(word)
 
-    process(labels, reduce, filter, keep_files, verbose, outputfile, hideCheckouts)
+    process(labels, reduce, filter, keep_files, verbose, outputfile, hideCheckouts, shortLabels)
     return 0
 
 if __name__ == '__main__':

--- a/sandbox/visdep.py
+++ b/sandbox/visdep.py
@@ -22,6 +22,10 @@ Where <switches> are:
                     tred`` for more information. This is recommended for many
                     muddle dependency trees.
 
+  -c | -hide-checkouts
+                    Omits the checkout nodes from the graph. This is recommended
+                    in most cases.
+
   -f[ilter] <name>  Tell xdot.py to use the named graphviz filter (one of
                     dot, neato, twopi, circo or fdp). The default is dot.
 
@@ -45,7 +49,7 @@ import subprocess
 import sys
 
 def process(labels, reduce=False, filter='dot', keep_files=False,
-            verbose=False, outputfile=None):
+            verbose=False, outputfile=None, hideCheckouts=False):
 
     # The first program we want to run is in the sandbox with us
     thisdir = os.path.split(__file__)[0]
@@ -62,6 +66,8 @@ def process(labels, reduce=False, filter='dot', keep_files=False,
                 print 'Outut dot file is', dotfile_path1
             # Labels may contain parentheses
             labels2 = []
+            if hideCheckouts:
+                labels2.append('--hide-checkouts')
             for label in labels:
                 labels2.append("'%s'"%label)
             retcode = subprocess.call('%s %s'%(visualiser, ' '.join(labels2)),
@@ -137,6 +143,7 @@ def main(args):
     filter = 'dot'
     labels = []
     outputfile = None
+    hideCheckouts = False
 
     while args:
         word = args.pop(0)
@@ -154,13 +161,15 @@ def main(args):
         elif word in ('-o', '-output'):
             outputfile = args[0]
             args = args[1:]
+        elif word in ('-c', '-hide-checkouts'):
+            hideCheckouts = True
         elif word[0] == '-':
             print 'Unrecognised switch', word
             return
         else:
             labels.append(word)
 
-    process(labels, reduce, filter, keep_files, verbose, outputfile)
+    process(labels, reduce, filter, keep_files, verbose, outputfile, hideCheckouts)
     return 0
 
 if __name__ == '__main__':

--- a/sandbox/visualise-dependencies.py
+++ b/sandbox/visualise-dependencies.py
@@ -170,11 +170,19 @@ def do_deps(gbuilder, goal):
 			if newnode:
 					do_deps(gbuilder, str(dep))
 
-def process(goals):
+def process(args):
+        goals = []
 
-	if goals and goals[0] in ('-h', '-help', '--help'):
-		print __doc__
-		sys.exit(0)
+        while args:
+            word = args.pop(0)
+            if word in ('-h', '-help', '--help'):
+                print __doc__
+                return
+            elif word[0] == '-':
+                print 'Unrecognised switch',word
+                return
+            else:
+                goals.append(word)
 
 	## ... find a build tree
 	original_dir = os.getcwd()

--- a/sandbox/visualise-dependencies.py
+++ b/sandbox/visualise-dependencies.py
@@ -11,6 +11,8 @@ provide a list of goal labels on the command-line.
 Options:
     --hide-checkouts  Omits checkout directories from the graph
                       (recommended in most cases)
+    --short-labels    Uses short, human-friendly label names (usually
+                      worthwhile but produces confusing output in some cases)
 
 For example:
 	visualise-dependencies.py  package:*{linux}/postinstalled
@@ -179,6 +181,7 @@ def do_deps(gbuilder, goal):
 def process(args):
         goals = []
         omitCheckouts = False
+        shortLabels = False
 
         while args:
             word = args.pop(0)
@@ -187,6 +190,8 @@ def process(args):
                 return
             elif word in ('--hide-checkouts'):
                 omitCheckouts = True
+            elif word in ('--short-labels'):
+                shortLabels = True
             elif word[0] == '-':
                 print 'Unrecognised switch',word
                 return
@@ -327,10 +332,16 @@ def process(args):
 		# else loop forever
 
 	# Now tidy up the conflated display names:
-	for n in Node.all_nodes.values():
-		if len(n.auxNames)>0:
-			tmp = n.displayname.rsplit('/',1)
-			n.displayname = '%s/\\n%s'%(tmp[0],tmp[1])
+        if shortLabels:
+            for n in Node.all_nodes.values():
+                n.displayname = n.displayname.rsplit('/',1)[0]
+                if n.displayname.startswith('package:'):
+                    n.displayname = n.displayname[8:]
+        else:
+            for n in Node.all_nodes.values():
+                    if len(n.auxNames)>0:
+                            tmp = n.displayname.rsplit('/',1)
+                            n.displayname = '%s/\\n%s'%(tmp[0],tmp[1])
 
 	print 'digraph muddle {'
 


### PR DESCRIPTION
A couple of new options to visdep.py which are handy with large dangly build descriptions:
````
  -c | -hide-checkouts
                    Omits the checkout nodes from the graph. This is recommended
                    in most cases.

  -s[hort-labels]   Uses short node labels. This makes the graph easier to read,
                    but can cause confusion in some cases.
````